### PR TITLE
Don't fail when `agents` directory doesn't exist. Fix #28

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -223,6 +223,8 @@ class Config():
 
     def get_agents(self):
         memories_dir = "agents"
+        if not os.path.exists(memories_dir):
+            os.makedirs(memories_dir)
         agents = []
         for file in os.listdir(memories_dir):
             if file.endswith(".yaml"):


### PR DESCRIPTION
After a git clone of this repository, the `agents` directory doesn't exist and function `get_agents` fails. This commit create the directory if it doesn't exist yet.