### PR TITLE
Prefix API_URI with NEXT_PUBLIC_

### DIFF
--- a/frontend/components/agent/AgentAdmin.js
+++ b/frontend/components/agent/AgentAdmin.js
@@ -12,11 +12,11 @@ export default function AgentCommandsList({ friendly_name, name, args, enabled }
   const agentName = useRouter().query.agent;
   const [newName, setNewName] = useState("");
   const handleDelete = async () => {
-    await axios.delete(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}`)
+    await axios.delete(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}`)
     mutate(`agents`);
   };
   const handleRename = async () => {
-    await axios.put(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}`, { new_name: newName })
+    await axios.put(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}`, { new_name: newName })
     mutate(`agents`);
   };
   return (

--- a/frontend/components/agent/AgentChat.js
+++ b/frontend/components/agent/AgentChat.js
@@ -12,7 +12,7 @@ export default function AgentChat() {
   const [message, setMessage] = useState("");
   const agentName = useRouter().query.agent;
   const MessageAgent = async (message) => {
-    const response = await axios.post(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/chat`, { prompt: message }).data.response;
+    const response = await axios.post(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/chat`, { prompt: message }).data.response;
     setChatHistory((old) => [
       ...old,
       `You: ${message}`,

--- a/frontend/components/agent/AgentCommand.js
+++ b/frontend/components/agent/AgentCommand.js
@@ -12,7 +12,7 @@ export default function AgentCommandsList({ friendly_name, name, args, enabled }
   //const [open, setOpen] = useState(false);
   //const [theArgs, setTheArgs] = useState({...args});
   const handleToggleCommand = async () => {
-    await axios.patch(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/command`, { command_name: friendly_name, enable: enabled? "false" : "true" });
+    await axios.patch(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/command`, { command_name: friendly_name, enable: enabled? "false" : "true" });
     mutate(`agent/${agentName}/commands`);
   };
   /*

--- a/frontend/components/agent/AgentCommandList.js
+++ b/frontend/components/agent/AgentCommandList.js
@@ -13,7 +13,7 @@ import AgentCommand from "./AgentCommand";
 export default function AgentCommandList({ data }) {
   const agentName = useRouter().query.agent;
   const handleToggleAllCommands = async () => {
-    await axios.patch(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/command`, { command_name: "*", enable: data.every((command) => command.enabled) ? "false" : "true" });
+    await axios.patch(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/command`, { command_name: "*", enable: data.every((command) => command.enabled) ? "false" : "true" });
     mutate(`agent/${agentName}/commands`);
   }
   return (

--- a/frontend/components/agent/AgentControl.js
+++ b/frontend/components/agent/AgentControl.js
@@ -73,7 +73,7 @@ export default function AgentControl({ data }) {
         setOpen(false);
     };
     const agentName = useRouter().query.agent;
-    const commands = useSWR(`agent/${agentName}/commands`, async () => (await axios.get(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/command`)).data.commands);
+    const commands = useSWR(`agent/${agentName}/commands`, async () => (await axios.get(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/command`)).data.commands);
     return (<>
         <AppBar position="relative" open={open}>
             <Toolbar sx={{ display: "flex", justifyContent: "space-between" }}>

--- a/frontend/components/agent/AgentInstruct.js
+++ b/frontend/components/agent/AgentInstruct.js
@@ -12,7 +12,7 @@ export default function AgentInstruct() {
   const [instruction, setInstruction] = useState("");
   const agentName = useRouter().query.agent;
   const InstructAgent = async () => {
-    const response = (await axios.post(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/instruct`, { prompt: instruction })).data.response;
+    const response = (await axios.post(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/instruct`, { prompt: instruction })).data.response;
     console.log(response);
     setResponseHistory((old) => [
       ...old,

--- a/frontend/components/agent/AgentObjective.js
+++ b/frontend/components/agent/AgentObjective.js
@@ -13,9 +13,9 @@ export default function AgentObjective() {
     const [running, setRunning] = useState(false);
     const [objective, setObjective] = useState("");
     const agentName = useRouter().query.agent;
-    const taskStatus = useSWR(`agent/${agentName}/task`, async () => (running ? (await axios.get(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/task`)).data.output : null), { refreshInterval: running?3000:0, revalidateOnFocus: false });
+    const taskStatus = useSWR(`agent/${agentName}/task`, async () => (running ? (await axios.get(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/task`)).data.output : null), { refreshInterval: running?3000:0, revalidateOnFocus: false });
     const queryRunning = useCallback(async () => {
-        setRunning((await axios.get(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/task/status`)).data.status);
+        setRunning((await axios.get(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/task/status`)).data.status);
     }, [agentName]);
     useEffect(() => {
         queryRunning();
@@ -23,10 +23,10 @@ export default function AgentObjective() {
 
     const toggleRunning = async () => {
         if (running) {
-            await axios.post(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/task`);
+            await axios.post(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/task`);
         }
         else {
-            await axios.post(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/task`, { objective: objective });
+            await axios.post(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}/task`, { objective: objective });
         }
         await queryRunning();
         mutate("agents");

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -74,7 +74,7 @@ const DrawerHeader = styled('div')(({ theme }) => ({
 export default function App({ Component, pageProps }) {
   const [open, setOpen] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
-  const agents = useSWR('agents', async () => (await axios.get(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent`)).data.agents);
+  const agents = useSWR('agents', async () => (await axios.get(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent`)).data.agents);
 
   const themeGenerator = (darkMode) =>
     createTheme({

--- a/frontend/pages/agent/[agent].js
+++ b/frontend/pages/agent/[agent].js
@@ -5,6 +5,6 @@ import AgentControl from '@/components/agent/AgentControl';
 import ContentSWR from '@/components/content/ContentSWR';
 export default function Agent() {
     const agentName = useRouter().query.agent;
-    const agent = useSWR(`agent/${agentName}`, async () => (await axios.get(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}`)).data);
+    const agent = useSWR(`agent/${agentName}`, async () => (await axios.get(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent/${agentName}`)).data);
     return <ContentSWR swr={agent} content={AgentControl} />;
 }

--- a/frontend/pages/new_agent.js
+++ b/frontend/pages/new_agent.js
@@ -6,7 +6,7 @@ import { mutate } from "swr"
 export default function Home() {
   const [name, setName] = useState("");
   const handleCreate = async () => {
-    await axios.post(`${process.env.API_URI ?? 'http://localhost:5000'}/api/agent`, { agent_name: name });
+    await axios.post(`${process.env.NEXT_PUBLIC_API_URI ?? 'http://localhost:5000'}/api/agent`, { agent_name: name });
     mutate("agents");
   }
   return <Container>


### PR DESCRIPTION
Rename environment variable API_URI to NEXT_PUBLIC_API_URI, to allow to customize it, because only environment variables prefixed with NEXT_PUBLIC_ are exposed to the browser (see https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser).