### PR TITLE
Use Union[] instead of | for type

### DIFF
--- a/commands/google.py
+++ b/commands/google.py
@@ -1,3 +1,4 @@
+from typing import Union
 import json
 from duckduckgo_search import ddg
 from Config import Config
@@ -23,7 +24,7 @@ class google(Commands):
             search_results.append(j)
         return json.dumps(search_results, ensure_ascii=False, indent=4)
 
-    def google_official_search(self, query: str, num_results: int = 8) -> str | list[str]:
+    def google_official_search(self, query: str, num_results: int = 8) -> Union[str, list[str]]:
         from googleapiclient.discovery import build
         from googleapiclient.errors import HttpError
 


### PR DESCRIPTION
Use Python syntax instead of TypeScript :) one for an union of to types.

Fixes the following error:
```
ERROR in app: Exception on /api/agent/Agent-LLM/command [GET]
Traceback (most recent call last):
  File "~/agent-llm/.venv/lib/python3.9/site-packages/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "~/agent-llm/.venv/lib/python3.9/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/flask_restful/__init__.py", line 467, in wrapper
    resp = resource(*args, **kwargs)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/flask/views.py", line 107, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/flask_restful/__init__.py", line 582, in dispatch_request
    resp = meth(*args, **kwargs)
  File "~/agent-llm/app.py", line 86, in get
    commands = Commands(agent_name)
  File "~/agent-llm/Commands.py", line 10, in __init__
    self.commands = self.load_commands()
  File "~/agent-llm/Commands.py", line 39, in load_commands
    module = importlib.import_module(f"commands.{module_name}")
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "~/agent-llm/commands/google.py", line 8, in <module>
    class google(Commands):
  File "~/agent-llm/commands/google.py", line 26, in google
    def google_official_search(self, query: str, num_results: int = 8) -> str | list[str]:
TypeError: unsupported operand type(s) for |: 'type' and 'types.GenericAlias'
```