### PR TITLE
Add missing self to llamacpp new_text_callback

### DIFF
--- a/provider/llamacpp.py
+++ b/provider/llamacpp.py
@@ -13,7 +13,7 @@ class AIProvider:
             self.model = Model(ggml_model=CFG.MODEL_PATH, n_ctx=self.max_tokens)
             # TODO: Need to reseach to add temperature, no obvious flag.
 
-    def new_text_callback(text: str):
+    def new_text_callback(self, text: str):
         print(text, end="", flush=True)
 
     def instruct(self, prompt):


### PR DESCRIPTION
Fix:
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "~/agent-llm/AgentLLM.py", line 282, in run_task
    task = self.execute_next_task()
  File "~/agent-llm/AgentLLM.py", line 254, in execute_next_task
    self.response = self.execution_agent(self.primary_objective, this_task_name, this_task_id)
  File "~/agent-llm/AgentLLM.py", line 221, in execution_agent
    self.response = self.run(prompt)
  File "~/agent-llm/AgentLLM.py", line 71, in run
    self.response = self.instruct(prompt)
  File "~/agent-llm/provider/llamacpp.py", line 20, in instruct
    output = self.model.generate(f"Q: {prompt}", n_predict=55, new_text_callback=self.new_text_callback, n_threads=8)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/pyllamacpp/model.py", line 120, in generate
    pp.llama_generate(self._ctx, self.gpt_params, self._call_new_text_callback, self._call_grab_text_callback, verbose)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/pyllamacpp/model.py", line 84, in _call_new_text_callback
    Model._new_text_callback(text)
TypeError: new_text_callback() takes 1 positional argument but 2 were given
```