### PR TITLE
Convert result of Task.get_output to str

### DIFF
--- a/AgentLLM.py
+++ b/AgentLLM.py
@@ -267,7 +267,7 @@ class AgentLLM:
         return task
 
     def get_output(self):
-        return self.output_list
+        return "".join(self.output_list)
 
     def stop_running(self):
         self.running = False

--- a/frontend/components/agent/AgentObjective.js
+++ b/frontend/components/agent/AgentObjective.js
@@ -59,11 +59,9 @@ export default function AgentObjective() {
                             elevation={5}
                             sx={{ padding: "0.5rem", overflowY: "auto", height: "60vh" }}
                         >
-                            {taskStatus.data.map((message, index) => (
-                                <pre key={index} style={{ margin: 0, whiteSpace: "pre-wrap" }}>
-                                    {message}
-                                </pre>
-                            ))}
+                            <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
+                                {taskStatus.data}
+                            </pre>
                         </Paper>
                     </>
                     : null


### PR DESCRIPTION
Currently, there is a typing mismatch:
* `AgentLLM.get_output` method returns a list of strings
* `Config.get_task_output` method expects that `AgentLLM.get_output` returns a string
* The frontend component `AgentObjective.js` expects that the response generated by `Config.get_task_output` contains an array of strings

This commit modifies `AgentLLM.get_output` to return a string and `AgentObjective.js` to expect a string.

This fixes exception:
```
Traceback (most recent call last):
  File "~/agent-llm/.venv/lib/python3.9/site-packages/uvicorn/protocols/http/httptools_impl.py", line 436, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "~/agent-llm/.venv/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/fastapi/applications.py", line 276, in __call__
    await super().__call__(scope, receive, send)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "~/agent-llm/.venv/lib/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/starlette/middleware/cors.py", line 84, in __call__
    await self.app(scope, receive, send)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "~/agent-llm/.venv/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "~/agent-llm/.venv/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "~/agent-llm/.venv/lib/python3.9/site-packages/fastapi/routing.py", line 237, in app
    raw_response = await run_endpoint_function(
  File "~/agent-llm/.venv/lib/python3.9/site-packages/fastapi/routing.py", line 163, in run_endpoint_function
    return await dependant.call(**values)
  File "~/agent-llm/app.py", line 170, in get_task_output
    return TaskOutput(output=output, message="Task agent is still running")
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for TaskOutput
output
  str type expected (type=type_error.str)
```
