### PR TITLE
Don't try to store an empty result

### DIFF
--- a/AgentLLM.py
+++ b/AgentLLM.py
@@ -102,11 +102,12 @@ class AgentLLM:
         return self.response
 
     def store_result(self, task_name: str, result: str):
-        result_id = ''.join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(64))
-        if (len(self.collection.get(ids=[result_id], include=[])["ids"]) > 0):
-            self.collection.update(ids=result_id, documents=result, metadatas={"task": task_name, "result": result})
-        else:
-            self.collection.add(ids=result_id, documents=result, metadatas={"task": task_name, "result": result})
+        if result:
+            result_id = ''.join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(64))
+            if (len(self.collection.get(ids=[result_id], include=[])["ids"]) > 0):
+                self.collection.update(ids=result_id, documents=result, metadatas={"task": task_name, "result": result})
+            else:
+                self.collection.add(ids=result_id, documents=result, metadatas={"task": task_name, "result": result})
 
     def context_agent(self, query: str, top_results_num: int, long_term_access: bool) -> List[str]:
         if long_term_access:


### PR DESCRIPTION
When an agent fails (for example: `llama_generate: error: prompt is too long (2215 tokens, max 1996)`), it returns no result. This PR ensures that a call to `store_result` doesn't raise an exception when result is empty.

So, it fixes the exception below (but doesn't fix the "prompt too long" error that occurs before):
```
llama_generate: error: prompt is too long (2215 tokens, max 1996)
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "~/agent-llm/AgentLLM.py", line 282, in run_task
    task = self.execute_next_task()
  File "~/agent-llm/AgentLLM.py", line 254, in execute_next_task
    self.response = self.execution_agent(self.primary_objective, this_task_name, this_task_id)
  File "~/agent-llm/AgentLLM.py", line 221, in execution_agent
    self.response = self.run(prompt)
  File "~/agent-llm/AgentLLM.py", line 73, in run
    self.store_result(task, self.response)
  File "~/agent-llm/AgentLLM.py", line 110, in store_result
    self.collection.add(ids=result_id, documents=result, metadatas={"task": task_name, "result": result})
  File "~/agent-llm/.venv/lib/python3.9/site-packages/chromadb/api/models/Collection.py", line 89, in add
    raise ValueError("You must provide either embeddings or documents, or both")
ValueError: You must provide either embeddings or documents, or both
```