### PR TITLE
Add docker-compose for mac #61

### DIFF
--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "80:3000"
+    environment:
+      NEXT_PUBLIC_API_URI: http://backend:5001
+    env_file:
+      - .env
+    depends_on:
+      - backend
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile-backend
+    ports:
+      - "5001:5000"
+    env_file:
+      - .env


### PR DESCRIPTION
Mac users should be able to use this docker-compose file with: 

`docker-compose -f docker-compose-mac.yml up -d --build`