### PR TITLE
Docker Cleanup

### DIFF
--- a/Dockerfile-backend
+++ b/Dockerfile-backend
@@ -2,20 +2,22 @@
 FROM python:3.10-slim-buster AS base
 WORKDIR /app
 COPY requirements.txt ./
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends git build-essential
-RUN apt-get install g++ -y
-RUN pip install --upgrade pip
-RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --force-reinstall --no-cache-dir hnswlib
-RUN apt-get remove -y git build-essential
-RUN apt-get install libgomp1 -y
-RUN apt-get install git -y
-RUN apt-get autoremove -y
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git build-essential && \
+    apt-get install g++ -y && \
+    pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --force-reinstall --no-cache-dir hnswlib && \
+    apt-get remove -y git build-essential && \
+    apt-get install libgomp1 -y && \
+    apt-get install git -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
-# Run FastAPI app with Uvicorn
-FROM base AS uvicorn
-COPY . /app
+#Run FastAPI app with Uvicorn
+FROM scratch AS uvicorn
+COPY --from=base / /
+WORKDIR /app
+COPY . .
 EXPOSE 5000
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "7437"]

--- a/Dockerfile-mac-backend
+++ b/Dockerfile-mac-backend
@@ -2,18 +2,20 @@
 FROM python:3.10-slim-buster AS base
 WORKDIR /app
 COPY requirements-mac.txt ./
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends git build-essential
-RUN pip install --upgrade pip
-RUN pip install --no-cache-dir -r requirements-mac.txt
-RUN apt-get remove -y git build-essential
-RUN apt-get install libgomp1 -y
-RUN apt-get install git -y
-RUN apt-get autoremove -y
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git build-essential && \
+    pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements-mac.txt && \
+    apt-get remove -y git build-essential && \
+    apt-get install libgomp1 -y && \
+    apt-get install git -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Run FastAPI app with Uvicorn
-FROM base AS uvicorn
+FROM scratch AS uvicorn
+COPY --from=base / /
+WORKDIR /app
 COPY . /app
 EXPOSE 5000
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "7437"]

--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -1,22 +1,26 @@
 version: "3.8"
 services:
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
+    image: ghcr.io/josh-xt/agent-llm-frontend
+    init: true
     ports:
       - "80:3000"
-    environment:
-      NEXT_PUBLIC_API_URI: ${NEXT_PUBLIC_API_URI:-http://backend:7437}
     env_file:
       - .env
+    environment:
+      NEXT_PUBLIC_API_URI: ${NEXT_PUBLIC_API_URI:-http://backend:7437}
     depends_on:
       - backend
+
   backend:
     build:
       context: .
       dockerfile: Dockerfile-mac-backend
-    ports:
-      - "7437:7437"
+    init: true
     env_file:
       - .env
+    ports:
+      - "7437:7437"    
+    #volumes: # Optional persistent data
+    #  - ./data/agents:/app/agents:rw,delegated
+    #  - ./data/workspace:/app/WORKSPACE:rw,delegated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,24 @@
 version: "3.8"
 services:
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-    ports:
-      - "80:3000"
+    image: ghcr.io/josh-xt/agent-llm-frontend
+    init: true
+    env_file:
+      - .env
     environment:
       NEXT_PUBLIC_API_URI: ${NEXT_PUBLIC_API_URI:-http://backend:7437}
-    env_file:
-      - .env
+    ports:
+      - "80:3000"
     depends_on:
       - backend
+
   backend:
-    build:
-      context: .
-      dockerfile: Dockerfile-backend
-    ports:
-      - "7437:7437"
+    image: ghcr.io/josh-xt/agent-llm-backend
+    init: true
     env_file:
       - .env
+    ports:
+      - "7437:7437"
+    # volumes: # Optional persistent data
+    #   - ./data/agents:/app/agents:rw
+    #   - ./data/workspace:/app/WORKSPACE:rw

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,17 +117,17 @@ mv .env.example .env
 3. Run the following Docker command in the folder with your `.env` file:
 
 ```
-docker compose up -d --build
+docker compose up -d
 ```
 
 4. Access the web interface at http://localhost
 
 ### Running a Mac?
 
-You'll need to run `docker-compose` to build if the command above does not work.
+You'll need to run `docker compose` to build if the command above does not work.
 
 ```
-docker-compose -f docker-compose-mac.yml up -d --build
+docker compose -f docker-compose-mac.yml up -d
 ```
 
 ### Not using OpenAI? No problem!

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,13 @@
+# Get deps
+FROM node:14-alpine AS deps
+WORKDIR /deps
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
 # Build the Next.js app
 FROM node:14-alpine AS builder
 WORKDIR /app
-COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+COPY --from=deps /deps/node_modules /app/node_modules
 COPY . .
 RUN yarn build
 


### PR DESCRIPTION
- remove version from registry image so latest tag is always pulled

- include init so processes aren't running as pid 1

-  add optional persistent volumes for agents and workspaces

- Clamp layers from scratch on runner

- move deps from frontend to own build step for faster builds when using cached in CI