### PR TITLE
Expose Port 7437 in Dockerfile-backend & Dockerfile-mac-backend

### DIFF
--- a/Dockerfile-backend
+++ b/Dockerfile-backend
@@ -19,5 +19,5 @@ FROM scratch AS uvicorn
 COPY --from=base / /
 WORKDIR /app
 COPY . .
-EXPOSE 5000
+EXPOSE 7437
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "7437"]

--- a/Dockerfile-mac-backend
+++ b/Dockerfile-mac-backend
@@ -17,5 +17,5 @@ FROM scratch AS uvicorn
 COPY --from=base / /
 WORKDIR /app
 COPY . /app
-EXPOSE 5000
+EXPOSE 7437
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "7437"]


### PR DESCRIPTION
Since the port has changed to 7437, it should be exposed as well.