### PR TITLE
Fix #164

### DIFF
--- a/AgentLLM.py
+++ b/AgentLLM.py
@@ -130,6 +130,11 @@ class AgentLLM:
                 response_parts = []
                 for command in commands[0].split("\n"):
                     command = command.strip()
+                    # Check if the command starts with a number and strip out everything until the first letter
+                    if command and command[0].isdigit():
+                        first_letter = re.search(r"[a-zA-Z]", command)
+                        if first_letter:
+                            command = command[first_letter.start() :]
                     command_name, command_args = None, {}
                     # Extract command name and arguments using regex
                     command_regex = re.search(r"(\w+)\((.*)\)", command)

--- a/commands/searxng_commands.py
+++ b/commands/searxng_commands.py
@@ -13,7 +13,7 @@ class searxng_commands(Commands):
             self.commands = {"Searx Search": self.search_searx}
 
     def search_searx(self, query: str, category: str = "general") -> List[str]:
-        searx_url = CFG.SEARX_INSTANCE_URL.rstrip("/") + "/search"
+        searx_url = CFG.SEARXNG_INSTANCE_URL.rstrip("/") + "/search"
         payload = {
             "q": query,
             "categories": category,


### PR DESCRIPTION
- Fixes bad reference for `SEARXNG_INSTANCE_URL`
- Strips out everything on a new line for commands until the first letter so that the "1. " is not captured in the command name.