### PR TITLE
Embedding model to distilbert-base-uncased

### DIFF
--- a/AgentLLM.py
+++ b/AgentLLM.py
@@ -38,7 +38,7 @@ class AgentLLM:
         else:
             self.embedding_function = (
                 embedding_functions.SentenceTransformerEmbeddingFunction(
-                    model_name="all-MiniLM-L6-v2"
+                    model_name="distilbert-base-uncased"
                 )
             )
         self.chroma_persist_dir = f"agents/{agent_name}/memories"


### PR DESCRIPTION
It was brought to my attention that `all-MiniLM-L6-v2` cannot embed 500 tokens as I was expecting it to, so I have switched to `distilbert-base-uncased` for non-OpenAI models.  OpenAI still uses Ada.