### PR TITLE
Add error handling

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -107,5 +107,8 @@ class Commands:
         for name, value in command_args.items():
             if name in params:
                 params[name] = value
-        output = command_function(module, **params)
+        try:
+            output = command_function(module, **params)
+        except Exception as e:
+            output = f"Error: {str(e)}"
         return output


### PR DESCRIPTION
Add error handling to command execution to return an error of a command to to agent in the event of a failure instead of causing a crash.