### PR TITLE
Fix huggingchat provider POST api call

### DIFF
--- a/provider/huggingchat.py
+++ b/provider/huggingchat.py
@@ -11,7 +11,11 @@ class HuggingchatProvider:
     def instruct(self, prompt: str) -> str:
         session = Session()
         session.get(url="https://huggingface.co/chat/")
-        res = session.post(url="https://huggingface.co/chat/conversation")
+        res = session.post(
+            url="https://huggingface.co/chat/conversation",
+            json={"model": "OpenAssistant/oasst-sft-6-llama-30b-xor"},
+            headers={"Content-Type": "application/json"}
+        )
         assert res.status_code == 200, "Failed to create new conversation"
         conversation_id = res.json()["conversationId"]
         url = f"https://huggingface.co/chat/conversation/{conversation_id}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Huggingchat updated the api code as seen [here](https://huggingface.co/spaces/huggingchat/chat-ui/commit/06e879dcad186431d5527b7de7b3433df5cba230) 

Now you need to pass a json with a model key to the POST request.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
![image](https://user-images.githubusercontent.com/29787333/236251223-59d3d543-6d39-4ae4-aeba-e99886362738.png)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] My change works!
